### PR TITLE
Node backend app deployment to GCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+.sass-cache
+.tmp
+node_modules
+*.log
+node/config.js
+

--- a/node/Gruntfile.js
+++ b/node/Gruntfile.js
@@ -1,0 +1,145 @@
+var Promise = require('promise'),
+    grunt = require('grunt'),
+    spawn = Promise.denodeify(grunt.util.spawn),
+    log = grunt.log,
+    path = require('path'),
+    tmpdir = require('os').tmpdir();
+
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        gce: {
+            project: 'mmobdevlab',
+            zone: 'europe-west1-b',
+            instance: 'mmdl',
+            dir: '/apps/mmdl-backend',
+            script: "<%= gce.dir %>/app.js"
+        }
+    });
+
+    grunt.registerTask('gce:deploy', function(instance) {
+        var cfg = grunt.config('gce');
+        var doneFn = this.async();
+
+        var filename = 'mmdl-backend-' + Date.now() + '.tar.gz',
+            localpath = path.join(tmpdir, filename),
+            remotepath = '/tmp/' + filename;
+
+        getHostIP(cfg.project, cfg.zone, instance || cfg.instance).then(
+            function(host) {
+                targz('.', localpath, ['./gce', './node_modules', './Gruntfile.js']).
+                then(scp.bind(null, localpath, remotepath, host)).
+                then(execRemote.bind(null, 'sudo tar xzf ' + remotepath + ' -C ' + cfg.dir, host)).
+                then(execRemote.bind(null, 'cd ' + cfg.dir + ' && sudo npm install', host)).
+                then(execRemote.bind(null, 'sudo forever restart ' + cfg.script, host)).
+                done(doneFn.bind(null, true), doneFn.bind(null, false));
+            },
+            function(err) {
+                log.error(err);
+                doneFn(false);
+            })
+    });
+
+    grunt.registerTask('gce:start', function(instance) {
+        var cfg = grunt.config('gce');
+        execRemoteAndDone(cfg,
+            'sudo forever start ' + cfg.script,
+            instance,
+            this.async());
+    });
+
+    grunt.registerTask('gce:stop', function(instance) {
+        var cfg = grunt.config('gce');
+        execRemoteAndDone(cfg,
+            'sudo forever stop ' + cfg.script,
+            instance,
+            this.async());
+    });
+
+    grunt.registerTask('gce:ps', function(instance) {
+        execRemoteAndDone(grunt.config('gce'),
+            'sudo forever list',
+            instance,
+            this.async());
+    });
+};
+
+function targz(dir, dst, exclude) {
+    var args = ['czvf', dst];
+    (exclude || []).forEach(function(p) {
+        args.push('--exclude', p)
+    });
+    args.push('.');
+    log.writeln('Creating archive at', dst);
+    return spawn({
+        cmd: 'tar',
+        args: args,
+        opts: {cwd: dir, stdio: 'inherit'}
+    });
+}
+
+function scp(localpath, remotepath, host) {
+    var dst = host + ':' + remotepath;
+    log.writeln('scp', localpath, dst);
+    return spawn({
+        cmd: 'scp',
+        args: [
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'CheckHostIP=no',
+            '-o', 'StrictHostKeyChecking=no',
+            localpath, dst
+        ],
+        opts: {stdio: 'inherit'}
+    });
+}
+
+function execRemote(cmd, host) {
+    log.writeln(host + ':', cmd);
+    return spawn({
+        cmd: 'ssh',
+        args: [
+            '-o', 'UserKnownHostsFile=/dev/null',
+            '-o', 'CheckHostIP=no',
+            '-o', 'StrictHostKeyChecking=no',
+            host, cmd
+        ],
+        opts: {stdio: 'inherit'}
+    });
+}
+
+function execRemoteAndDone(cfg, cmd, instance, doneFn) {
+    getHostIP(cfg.project, cfg.zone, instance || cfg.instance).
+    then(execRemote.bind(null, cmd)).
+    done(doneFn.bind(null, true), function(err) {
+        log.error(err);
+        doneFn(false);
+    });
+}
+
+function getHostIP(project, zone, instance) {
+    if (/^\d{1,3}(\.\d{1,3}){3}$/.test(instance)) {
+        // no need to lookup if instance is already an ip address
+        return Promise.from(instance);
+    }
+
+    var args = ['--project', project, '--format', 'json', 'getinstance', instance, '--zone', zone];
+    log.writeln('gcutil', args.join(' '));
+
+    return new Promise(function resolver(resolve, reject) {
+        spawn({
+            cmd: 'gcutil',
+            args: args
+        }).then(
+            function success(output) {
+                var data = JSON.parse(String(output));
+                if (data.status !== 'RUNNING') {
+                    reject('Instance "' + instance + '" is not running: ' + data.status);
+                    return;
+                }
+                resolve(data.networkInterfaces[0].accessConfigs[0].natIP);
+            },
+            function error(err) {
+                reject(err.message || err);
+            });
+    });
+}

--- a/node/app.js
+++ b/node/app.js
@@ -1,5 +1,6 @@
 var PORT = 3000;
 
+var pkg = require('./package.json');
 var express = require('express');
 var deviceHandler = require('./device-handler.js');
 var pushHandler = require('./push-handler.js');
@@ -50,6 +51,13 @@ app.post('/device/delete', deviceHandler.remove);
 app.post('/device/edit', deviceHandler.edit);
 
 app.post('/push/url', pushHandler.pushUrl);
+
+// A simple handler that returns backend version.
+// Used for health checks and such.
+app.get('/version', function(req, res) {
+    res.set('Content-Type', 'text/plain');
+    res.send(pkg.version);
+});
 
 app.listen(PORT);
 console.log('Listening on port '+PORT);

--- a/node/config.sample.js
+++ b/node/config.sample.js
@@ -1,4 +1,4 @@
 exports.dbHost = 'localhost';
 exports.dbUsername = 'root';
-exports.dbPassword = 'root';
-exports.dbPort = 8891;
+exports.dbPassword = '';
+exports.dbPort = 3306;

--- a/node/gce/README.md
+++ b/node/gce/README.md
@@ -1,0 +1,136 @@
+# GCE project setup
+
+1. Node app is currently listening on port `3000`, so let's add it to the firewall using `gcutil` tool:
+
+    <pre>gcutil --project=mmobdevlab addfirewall --allowed='tcp:3000' \
+           --description='Allow incoming TCP 3000' allow-3000
+    </pre>
+
+2. Create a new GCE instance using the same `gcutil`:
+
+	<pre>gcutil --project mmobdevlab addinstance mmdl \
+           --automatic_restart --auto_delete_boot_disk=true --on_host_maintenance=migrate \
+           --zone=europe-west1-b --machine_type=f1-micro \
+           --image=projects/debian-cloud/global/images/backports-debian-7-wheezy-v20140415 \
+           --metadata_from_file startup-script:gce/startup-script.sh
+    </pre>
+
+  You should be able to see something similar to this:
+
+  <pre>
+    Table of resources:
+    +------+----------------+---------------+----------------+---------+
+    | name | network-ip     | external-ip   | zone           | status  |
+    +------+----------------+---------------+----------------+---------+
+    | mmdl | 10.240.1.2     | 1.2.3.4       | europe-west1-b | RUNNING |
+    +------+----------------+---------------+----------------+---------+
+  </pre>
+
+  Note `external-ip` value - we'll need it later.
+
+3. Create a new CloudSQL instance. This time we'll use `gcloud` util. 
+  Note that `authorized-networks` contains the `external-ip` of the GCE instance created earlier:
+
+  <pre>gcloud --project mmobdevlab sql instances create mmdlsql \
+           --tier D0 --region europe-west1 --gce-zone europe-west1-b \
+           --activation-policy ALWAYS --assign-ip --authorized-networks 1.2.3.4
+  </pre>
+
+4. Set root password for the CloudSQL instance we've just created:
+
+  <pre>
+    gcloud --project mmobdevlab sql instances set-root-password mmdlsql \
+           --password &lt;my-secret-password>
+  </pre>
+
+5. Get IP address of the CloudSQL instance. We'll need it later:
+
+  <pre>
+    gcloud --project mmobdevlab sql instances get mmdlsql
+  </pre>
+
+  You should be looking for `ipAddresses` section:
+
+  <pre>
+     ipAddresses:
+       [
+         ipAddress: 4.3.2.1
+       ]
+  </pre>
+
+6. Almost done. Copy `config.sample.js` into `config.js` and update mysql settings
+
+7. We're now ready to deploy the node app:
+
+  <pre>
+  grunt gce:deploy
+  </pre>
+
+  If you know the IP address of the GCE instance, you can add it to deploy command. This should speed up things a little:
+
+  <pre>
+  grunt gce:deploy:1.2.3.4
+  </pre>
+
+  You might notice an error at the end of the very first deployment:
+  > error:   Error restarting process: /apps/mmdl-backend/app.js
+  > error:   Cannot find forever process: /apps/mmdl-backend/app.js
+
+  That's ok. We can start the app with the following:
+
+  <pre>
+  grunt gce:start
+  </pre>
+
+  The output should look like this:
+  > info:    Forever processing file: /apps/mmdl-backend/app.js
+
+  If you want to make sure the process is running, execute:
+
+  <pre>
+  grunt gce:ps
+  </pre>
+
+  The output will look like:
+
+  <pre>
+  info:    Forever processes running
+  data:    uid      command         script                    forever pid  logfile                 uptime
+  data:    [0] zz9Y /usr/bin/nodejs /apps/mmdl-backend/app.js 3372    3374 /root/.forever/zz9Y.log 0:0:0:24.657
+  </pre>
+
+  You can also check whether the app is accessible and responding correctly:
+
+  <pre>
+  curl 1.2.3.4:3000/version
+  </pre>
+
+## Other useful commands
+
+If you ever wanted to connect to the CloudSQL instance from home or a work place, add [your ip address](https://www.google.com/#q=what's+my+ip) to `authorized-networks`:
+
+<pre>
+gcloud --project mmobdevlab sql instances patch mmdlsql \
+       --authorized-networks 1.2.3.4 5.6.7.8/13
+</pre>
+
+where `1.2.3.4` if the GCE instance IP address, and `5.6.7.8/13` is another IP range you want to access the CloudSQL instance from.
+
+It is now possible to connect to the instance with any mysql client:
+
+<pre>
+mysql -u root -h 4.3.2.1 -p 
+</pre>
+
+
+If you ever wanted to check out all of the GCE instance properties, you can do:
+
+<pre>
+gcutil --project mmobdevlab getinstance mmdl --zone europe-west1-b
+</pre>
+
+To delete GCE instance:
+
+<pre>
+gcutil --project mmobdevlab deleteinstance mmdl -f --zone europe-west1-b --delete_boot_pd
+</pre>

--- a/node/gce/startup-script.sh
+++ b/node/gce/startup-script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Install NodeJS, Git and MySQL client
+apt-get update && apt-get install -y nodejs git mysql-client
+# Many scripts use /usr/bin/node
+ln -s /usr/bin/nodejs /usr/bin/node
+
+# Instasll npm as it isn't included in the nodejs package
+curl http://registry.npmjs.org/npm/-/npm-1.4.7.tgz | tar xzf -
+cd package
+node cli.js install -g -f
+
+# Install long-running processes support
+npm install -g forever
+
+# Prepare empty dir for the backend app
+mkdir -p /apps/mmdl-backend

--- a/node/gplus-controller.js
+++ b/node/gplus-controller.js
@@ -1,4 +1,4 @@
-var googleapis = require('./googleapis');
+var googleapis = require('googleapis');
 var OAuth2 = googleapis.auth.OAuth2;
 
 exports.getUserId = function(idToken, successCallback, errorCallback) {

--- a/node/package.json
+++ b/node/package.json
@@ -6,6 +6,11 @@
     "express": "3.x",
     "jwt-simple": "0.1.x",
     "mysql": "2.0.x",
-    "node-gcm": "0.9.x"
+    "node-gcm": "0.9.x",
+    "googleapis": "^0.7.0"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.4",
+    "promise": "^4.0.0"
   }
 }


### PR DESCRIPTION
This PR adds deployment of the node backend app to GCE, at least until [Custom Runtime feature](https://www.youtube.com/watch?v=u3B1BhyXXdc) of App Engine is released.

Setup details are in `node/gce/README.md`.

@gauntface the project is already setup but I'll need your `google_compute_engine.pub` public ssh key.
